### PR TITLE
Support for the AMP-head metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,12 @@ This will update within the same `useLink` but will never go outside
 This hook accepts a string that will be used to set the `lang` property on the
 base `<html>` tag. Every time this string gets updated this will be reflected in the dom.
 
+### useAmp
+
+You can call `useAmp` to inject `html.amp = true` and the `ampScript`, depending on the first
+attribute the hook will decide whether or not you want a module, when passing `true` to the first
+argument the script will be injected as `script type module`.
+
 ## SSR
 
 We expose a method called `toStatic` that will return the following properties:
@@ -107,10 +113,18 @@ The reason we pass these as properties is to better support `gatsby`, ...
 If you need to stringify these you can use the following algo:
 
 ```js
-const stringify = (title, metas, links) => {
+const stringify = (title, metas, links, ampScript) => {
   const visited = new Set();
   return `
     <title>${title}</title>
+
+    ${
+      ampScript
+        ? `<script src={ampScript} async ${
+            ampScript.endsWith('mjs') ? 'type="module"' : ''
+          } />`
+        : ''
+    }
 
     ${metaQueue.reduce((acc, meta) => {
       if (!visited.has(meta.charset ? meta.keyword : meta[meta.keyword])) {
@@ -136,12 +150,12 @@ const stringify = (title, metas, links) => {
 import { toStatic } from 'hoofd';
 
 const reactStuff = renderToString();
-const { metas, links, title, lang } = toStatic();
-const stringified = stringify(title, metas, links);
+const { metas, links, title, lang, amp, ampScript } = toStatic();
+const stringified = stringify(title, metas, links, ampScript);
 
 const html = `
   <!doctype html>
-    <html lang="${lang}">
+    <html ${lang ? `lang="${lang}"` : ''} ${amp ? `amp` : ''}>
       <head>
         ${stringified}
       </head>

--- a/__tests__/ssr.test.tsx
+++ b/__tests__/ssr.test.tsx
@@ -44,13 +44,16 @@ describe('ssr', () => {
       useHead({
         title: 'hi',
         metas: [{ property: 'fb:admins', content: 'hi' }],
+        amp: 'nomodule',
       });
       return <p>hi</p>;
     };
 
     render(<MyComponent />);
     jest.runAllTimers();
-    const { title, metas } = toStatic();
+    const { title, metas, amp, ampScript } = toStatic();
+    expect(amp).toBeTruthy();
+    expect(ampScript).toEqual('https://cdn.ampproject.org/v0.js');
     expect(title).toEqual('hi');
     expect(metas).toEqual([{ content: 'hi', property: 'fb:admins' }]);
   });
@@ -91,6 +94,7 @@ describe('ssr', () => {
     const MyComponent = (props: any) => {
       useHead({
         title: 'hi',
+        amp: 'module',
         metas: [{ property: 'fb:admins', content: 'hi' }],
       });
       return props.children;
@@ -110,7 +114,9 @@ describe('ssr', () => {
       </MyComponent>
     );
     jest.runAllTimers();
-    const { title, metas } = toStatic();
+    const { title, metas, amp, ampScript } = toStatic();
+    expect(amp).toBeTruthy();
+    expect(ampScript).toEqual('https://cdn.ampproject.org/v0.mjs');
     expect(title).toEqual('bye');
     expect(metas).toEqual([{ content: 'bye', property: 'fb:admins' }]);
   });

--- a/__tests__/useAmp.test.tsx
+++ b/__tests__/useAmp.test.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom';
+import * as React from 'react';
+import { act, render, cleanup } from '@testing-library/react';
+import { useAmp } from '../src';
+import dispatcher from '../src/dispatcher';
+
+describe('useAmp', () => {
+  afterEach(() => {
+    cleanup();
+    dispatcher._reset!();
+  });
+
+  it('should fill in the amp-attributes (module)', async () => {
+    jest.useFakeTimers();
+    const Amp = () => {
+      useAmp(true, false);
+      return <p>hi</p>;
+    };
+
+    await act(async () => {
+      await render(<Amp />);
+    });
+    jest.runAllTimers();
+    expect(
+      document.getElementsByTagName('html')[0].getAttribute('amp')
+    ).toEqual('');
+
+    const script = document.querySelectorAll(
+      `script[src="https://cdn.ampproject.org/v0.mjs"]`
+    )[0];
+    expect(script.getAttribute('async')).toEqual('');
+    expect(script.getAttribute('type')).toEqual('module');
+    expect(script.getAttribute('src')).toEqual(
+      'https://cdn.ampproject.org/v0.mjs'
+    );
+  });
+
+  it('should fill in the amp-attributes (nomodule)', async () => {
+    jest.useFakeTimers();
+    const Amp = () => {
+      useAmp(false, false);
+      return <p>hi</p>;
+    };
+
+    await act(async () => {
+      await render(<Amp />);
+    });
+    jest.runAllTimers();
+    expect(
+      document.getElementsByTagName('html')[0].getAttribute('amp')
+    ).toEqual('');
+
+    const script = document.querySelectorAll(
+      `script[src="https://cdn.ampproject.org/v0.js"]`
+    )[0];
+    expect(script.getAttribute('async')).toEqual('');
+    expect(script.getAttribute('type')).not.toEqual('module');
+    expect(script.getAttribute('src')).toEqual(
+      'https://cdn.ampproject.org/v0.js'
+    );
+  });
+});

--- a/packages/gatsby-plugin-hoofd/gatsby-ssr.js
+++ b/packages/gatsby-plugin-hoofd/gatsby-ssr.js
@@ -10,6 +10,10 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
 
   setHeadComponents(
     [
+      amp && createElement('script', {
+        async: true,
+        src: 'https://cdn.ampproject.org/v0.js'
+      }),
       title && createElement('title', null, title),
       ...metas.map((meta) => createElement('meta', meta, null)),
       ...links.map((link) => createElement('link', link, null)),

--- a/packages/gatsby-plugin-hoofd/gatsby-ssr.js
+++ b/packages/gatsby-plugin-hoofd/gatsby-ssr.js
@@ -2,10 +2,10 @@ import { createElement } from 'react';
 import { toStatic } from 'hoofd';
 
 export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
-  const { title, metas, lang, links } = toStatic();
+  const { title, metas, lang, links, amp } = toStatic();
 
   if (lang) {
-    setHtmlAttributes({ lang });
+    setHtmlAttributes({ lang, amp });
   }
 
   setHeadComponents(

--- a/packages/gatsby-plugin-hoofd/gatsby-ssr.js
+++ b/packages/gatsby-plugin-hoofd/gatsby-ssr.js
@@ -12,7 +12,8 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
     [
       amp && createElement('script', {
         async: true,
-        src: ampScript
+        src: ampScript,
+        type: ampScript.endsWith('mjs') ? 'module' : undefined,
       }),
       title && createElement('title', null, title),
       ...metas.map((meta) => createElement('meta', meta, null)),

--- a/packages/gatsby-plugin-hoofd/gatsby-ssr.js
+++ b/packages/gatsby-plugin-hoofd/gatsby-ssr.js
@@ -2,7 +2,7 @@ import { createElement } from 'react';
 import { toStatic } from 'hoofd';
 
 export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
-  const { title, metas, lang, links, amp } = toStatic();
+  const { title, metas, lang, links, amp, ampScript } = toStatic();
 
   if (lang) {
     setHtmlAttributes({ lang, amp });
@@ -12,7 +12,7 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
     [
       amp && createElement('script', {
         async: true,
-        src: 'https://cdn.ampproject.org/v0.js'
+        src: ampScript
       }),
       title && createElement('title', null, title),
       ...metas.map((meta) => createElement('meta', meta, null)),

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -223,6 +223,7 @@ const createDispatcher = () => {
 
       return {
         amp,
+        ampScript: 'https://cdn.ampproject.org/v0.js',
         lang,
         title,
         links,

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -1,5 +1,7 @@
 import { Name, CharSet, HttpEquiv, Property } from '../types';
-import { isServerSide, ampScriptSrc } from '../utils';
+import { isServerSide } from '../utils';
+
+export const ampScriptSrc = 'https://cdn.ampproject.org/v0';
 
 export const META = 'M';
 export const TITLE = 'T';
@@ -223,9 +225,9 @@ const createDispatcher = () => {
 
       let ampScript;
       if (amp && amp === 'module') {
-        ampScript = 'https://cdn.ampproject.org/v0.mjs';
+        ampScript = ampScriptSrc + '.mjs';
       } else if (amp) {
-        ampScript = 'https://cdn.ampproject.org/v0.js';
+        ampScript = ampScriptSrc + '.js';
       }
 
       return {

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -65,6 +65,7 @@ const changeOrCreateMetaTag = (meta: MetaPayload) => {
  */
 const createDispatcher = () => {
   let lang: string;
+  let amp: boolean;
   let linkQueue: any[] = [];
   let titleQueue: string[] = [];
   let titleTemplateQueue: string[] = [];
@@ -122,6 +123,9 @@ const createDispatcher = () => {
       } else {
         linkQueue.push(payload);
       }
+    },
+    _setAmp: () => {
+      amp = true;
     },
     _removeFromQueue: (type: HeadType, payload: MetaPayload | string) => {
       if (type === TITLE || type === TEMPLATE) {
@@ -218,6 +222,7 @@ const createDispatcher = () => {
       currentTitleIndex = currentTitleTemplateIndex = currentMetaIndex = 0;
 
       return {
+        amp,
         lang,
         title,
         links,

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -65,7 +65,7 @@ const changeOrCreateMetaTag = (meta: MetaPayload) => {
  */
 const createDispatcher = () => {
   let lang: string;
-  let amp: boolean;
+  let amp: 'module' | 'nomodule' | undefined;
   let linkQueue: any[] = [];
   let titleQueue: string[] = [];
   let titleTemplateQueue: string[] = [];
@@ -124,8 +124,8 @@ const createDispatcher = () => {
         linkQueue.push(payload);
       }
     },
-    _setAmp: () => {
-      amp = true;
+    _setAmp: (isModule: boolean) => {
+      amp = isModule ? 'module' : 'nomodule';
     },
     _removeFromQueue: (type: HeadType, payload: MetaPayload | string) => {
       if (type === TITLE || type === TEMPLATE) {
@@ -221,9 +221,16 @@ const createDispatcher = () => {
       linkQueue = [];
       currentTitleIndex = currentTitleTemplateIndex = currentMetaIndex = 0;
 
+      let ampScript;
+      if (amp && amp === 'module') {
+        ampScript = 'https://cdn.ampproject.org/v0.mjs';
+      } else if (amp) {
+        ampScript = 'https://cdn.ampproject.org/v0.js';
+      }
+
       return {
         amp,
-        ampScript: amp && ampScriptSrc,
+        ampScript,
         lang,
         title,
         links,

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -1,5 +1,5 @@
 import { Name, CharSet, HttpEquiv, Property } from '../types';
-import { isServerSide } from '../utils';
+import { isServerSide, ampScriptSrc } from '../utils';
 
 export const META = 'M';
 export const TITLE = 'T';
@@ -223,7 +223,7 @@ const createDispatcher = () => {
 
       return {
         amp,
-        ampScript: 'https://cdn.ampproject.org/v0.js',
+        ampScript: amp && ampScriptSrc,
         lang,
         title,
         links,

--- a/src/hooks/useAmp.ts
+++ b/src/hooks/useAmp.ts
@@ -2,20 +2,31 @@ import dispatcher from '../dispatcher';
 import { isServerSide, ampScriptSrc } from '../utils';
 import { useEffect } from 'react';
 
-export const useAmp = () => {
-  if (isServerSide) {
-    dispatcher._setAmp();
+export const useAmp = (isModule: boolean, disabled?: boolean) => {
+  if (isServerSide && !disabled) {
+    dispatcher._setAmp(isModule);
   }
 
   useEffect(() => {
-    const nodeList = document.querySelectorAll(`script[src="${ampScriptSrc}"]`);
-    document.getElementsByTagName('html')[0].setAttribute('amp', '');
-    if (!nodeList[0]) {
-      const ampScript = document.createElement('script');
-      // @ts-ignore
-      ampScript.src = ampScriptSrc;
-      ampScript.async = true;
-      document.head.insertBefore(ampScript, document.head.firstChild);
+    if (!disabled) {
+      const nodeList = document.querySelectorAll(
+        `script[src="${ampScriptSrc}"]`
+      );
+      document.getElementsByTagName('html')[0].setAttribute('amp', '');
+
+      if (!nodeList[0]) {
+        const ampScript = document.createElement('script');
+        if (isModule) {
+          ampScript.setAttribute('type', 'module');
+        }
+
+        ampScript.setAttribute('async', '');
+        ampScript.setAttribute(
+          'src',
+          ampScriptSrc + (isModule ? '.mjs' : '.js')
+        );
+        document.head.insertBefore(ampScript, document.head.firstChild);
+      }
     }
-  }, []);
+  }, [disabled]);
 };

--- a/src/hooks/useAmp.ts
+++ b/src/hooks/useAmp.ts
@@ -1,8 +1,22 @@
 import dispatcher from '../dispatcher';
 import { isServerSide } from '../utils';
+import { useEffect } from 'react';
 
 export const useAmp = () => {
   if (isServerSide) {
     dispatcher._setAmp();
   }
+
+  useEffect(() => {
+    const nodeList = document.querySelectorAll(
+      'script[src="https://cdn.ampproject.org/v0.js"]'
+    );
+    document.getElementsByTagName('html')[0].setAttribute('amp', '');
+    if (!nodeList[0]) {
+      const ampScript = document.createElement('script');
+      ampScript.src = 'https://cdn.ampproject.org/v0.js';
+      ampScript.async = true;
+      document.head.insertBefore(ampScript, document.head.firstChild);
+    }
+  }, []);
 };

--- a/src/hooks/useAmp.ts
+++ b/src/hooks/useAmp.ts
@@ -1,4 +1,3 @@
-import { useEffect } from 'react';
 import dispatcher from '../dispatcher';
 import { isServerSide } from '../utils';
 
@@ -6,8 +5,4 @@ export const useAmp = () => {
   if (isServerSide) {
     dispatcher._setAmp();
   }
-
-  useEffect(() => {
-    document.getElementsByTagName('html')[0].setAttribute('amp', '');
-  }, []);
 };

--- a/src/hooks/useAmp.ts
+++ b/src/hooks/useAmp.ts
@@ -1,5 +1,5 @@
 import dispatcher from '../dispatcher';
-import { isServerSide } from '../utils';
+import { isServerSide, ampScriptSrc } from '../utils';
 import { useEffect } from 'react';
 
 export const useAmp = () => {
@@ -8,13 +8,12 @@ export const useAmp = () => {
   }
 
   useEffect(() => {
-    const nodeList = document.querySelectorAll(
-      'script[src="https://cdn.ampproject.org/v0.js"]'
-    );
+    const nodeList = document.querySelectorAll(`script[src="${ampScriptSrc}"]`);
     document.getElementsByTagName('html')[0].setAttribute('amp', '');
     if (!nodeList[0]) {
       const ampScript = document.createElement('script');
-      ampScript.src = 'https://cdn.ampproject.org/v0.js';
+      // @ts-ignore
+      ampScript.src = ampScriptSrc;
       ampScript.async = true;
       document.head.insertBefore(ampScript, document.head.firstChild);
     }

--- a/src/hooks/useAmp.ts
+++ b/src/hooks/useAmp.ts
@@ -1,0 +1,13 @@
+import { useEffect } from 'react';
+import dispatcher from '../dispatcher';
+import { isServerSide } from '../utils';
+
+export const useAmp = () => {
+  if (isServerSide) {
+    dispatcher._setAmp();
+  }
+
+  useEffect(() => {
+    document.getElementsByTagName('html')[0].setAttribute('amp', '');
+  }, []);
+};

--- a/src/hooks/useAmp.ts
+++ b/src/hooks/useAmp.ts
@@ -1,5 +1,5 @@
-import dispatcher from '../dispatcher';
-import { isServerSide, ampScriptSrc } from '../utils';
+import dispatcher, { ampScriptSrc } from '../dispatcher';
+import { isServerSide } from '../utils';
 import { useEffect } from 'react';
 
 export const useAmp = (isModule: boolean, disabled?: boolean) => {

--- a/src/hooks/useHead.ts
+++ b/src/hooks/useHead.ts
@@ -7,6 +7,7 @@ interface HeadObject {
   title?: string;
   language?: string;
   metas?: MetaOptions[];
+  amp?: boolean;
 }
 
 export function extractKeyword(meta: MetaOptions) {
@@ -19,7 +20,7 @@ export function extractKeyword(meta: MetaOptions) {
     : 'http-equiv';
 }
 
-export const useHead = ({ title, metas, language }: HeadObject) => {
+export const useHead = ({ title, metas, language, amp }: HeadObject) => {
   const hasMounted = useRef(false);
   const prevTitle = useRef<string | undefined>();
   const prevMetas = useRef<MetaPayload[]>();
@@ -57,6 +58,7 @@ export const useHead = ({ title, metas, language }: HeadObject) => {
   }, [metas]);
 
   if (isServerSide && !hasMounted.current) {
+    if (amp) dispatcher._setAmp();
     if (title) dispatcher._addToQueue(TITLE, title);
     if (language) dispatcher._setLang(language);
 
@@ -100,6 +102,10 @@ export const useHead = ({ title, metas, language }: HeadObject) => {
   }, [memoizedMetas]);
 
   useEffect(() => {
+    if (amp) {
+      document.getElementsByTagName('html')[0].setAttribute('amp', '');
+    }
+
     memoizedMetas.forEach((meta) => {
       dispatcher._addToQueue(META, meta);
     });

--- a/src/hooks/useHead.ts
+++ b/src/hooks/useHead.ts
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 import dispatcher, { META, MetaPayload, TITLE } from '../dispatcher';
-import { isServerSide } from '../utils';
+import { isServerSide, ampScriptSrc } from '../utils';
 import { MetaOptions } from './useMeta';
 
 interface HeadObject {
@@ -104,12 +104,12 @@ export const useHead = ({ title, metas, language, amp }: HeadObject) => {
   useEffect(() => {
     if (amp) {
       const nodeList = document.querySelectorAll(
-        'script[src="https://cdn.ampproject.org/v0.js"]'
+        `script[src="${ampScriptSrc}"]`
       );
       document.getElementsByTagName('html')[0].setAttribute('amp', '');
       if (!nodeList[0]) {
         const ampScript = document.createElement('script');
-        ampScript.src = 'https://cdn.ampproject.org/v0.js';
+        ampScript.src = ampScriptSrc;
         ampScript.async = true;
         document.head.insertBefore(ampScript, document.head.firstChild);
       }

--- a/src/hooks/useHead.ts
+++ b/src/hooks/useHead.ts
@@ -102,6 +102,19 @@ export const useHead = ({ title, metas, language, amp }: HeadObject) => {
   }, [memoizedMetas]);
 
   useEffect(() => {
+    if (amp) {
+      const nodeList = document.querySelectorAll(
+        'script[src="https://cdn.ampproject.org/v0.js"]'
+      );
+      document.getElementsByTagName('html')[0].setAttribute('amp', '');
+      if (!nodeList[0]) {
+        const ampScript = document.createElement('script');
+        ampScript.src = 'https://cdn.ampproject.org/v0.js';
+        ampScript.async = true;
+        document.head.insertBefore(ampScript, document.head.firstChild);
+      }
+    }
+
     memoizedMetas.forEach((meta) => {
       dispatcher._addToQueue(META, meta);
     });

--- a/src/hooks/useHead.ts
+++ b/src/hooks/useHead.ts
@@ -102,13 +102,10 @@ export const useHead = ({ title, metas, language, amp }: HeadObject) => {
   }, [memoizedMetas]);
 
   useEffect(() => {
-    if (amp) {
-      document.getElementsByTagName('html')[0].setAttribute('amp', '');
-    }
-
     memoizedMetas.forEach((meta) => {
       dispatcher._addToQueue(META, meta);
     });
+
     prevMetas.current = addedMetas.current = memoizedMetas;
 
     return () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import dispatcher from './dispatcher';
 export * from './hooks/useLang';
 export * from './hooks/useLink';
 export * from './hooks/useMeta';
+export * from './hooks/useAmp';
 export * from './hooks/useTitle';
 export * from './hooks/useTitleTemplate';
 export { useHead } from './hooks/useHead';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,1 +1,3 @@
 export const isServerSide = typeof document === 'undefined';
+
+export const ampScriptSrc = 'https://cdn.ampproject.org/v0.js';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,1 @@
 export const isServerSide = typeof document === 'undefined';
-
-export const ampScriptSrc = 'https://cdn.ampproject.org/v0';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,3 @@
 export const isServerSide = typeof document === 'undefined';
 
-export const ampScriptSrc = 'https://cdn.ampproject.org/v0.js';
+export const ampScriptSrc = 'https://cdn.ampproject.org/v0';


### PR DESCRIPTION
Currently this only adds support for the `html.amp` attribute and the script. This also adds it to the DOM in both hooks for services like prerender.io