### PR TITLE
fix(useTitle): Add template to useState dependencies

### DIFF
--- a/src/hooks/useTitle.ts
+++ b/src/hooks/useTitle.ts
@@ -18,7 +18,7 @@ export const useTitle = (title: string, template?: boolean) => {
         (prevTitle.current = title)
       );
     }
-  }, [title]);
+  }, [title, template]);
 
   useEffect(() => {
     hasMounted.current = true;
@@ -34,5 +34,5 @@ export const useTitle = (title: string, template?: boolean) => {
         prevTitle.current as string
       );
     };
-  }, []);
+  }, [template]);
 };


### PR DESCRIPTION
The `useEffect`s used in the `useTitle` hook make use of the `template` variable, but currently doesn't mention them as dependencies. This makes changes to `template` silent and doesn't allow changing the scope (title/template) of `useTitle` dynamically.