### PR TITLE
Support context API

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,30 @@ const html = `
 `;
 ```
 
+### Context API
+
+By default this package relies on a statically-initialized context provider to accumulate and
+dispatch `<head>` and `<meta>` changes. In cases where you may want to control the Dispatcher
+instance used, this module exports a `HoofdProvider` context provider and `createDispatcher`
+function for creating valid context instances.
+
+```jsx
+import { createDispatcher, HoofdProvider } from 'hoofd';
+
+function ssr(App) {
+  const dispatcher = createDispatcher();
+  const wrappedApp = (
+    <HoofdProvider value={dispatcher}>
+      <App />
+    </HoofdProvider>
+  );
+  const markup = renderToString(wrappedApp);
+  const { metas, links, title, lang, amp, ampScript } = dispatcher.toStatic();
+
+  // See example above for potential method to consume these static results.
+}
+```
+
 ## Goals
 
 - [x] React support

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -198,7 +198,7 @@ export const createDispatcher = () => {
           }
         : // istanbul ignore next
           undefined,
-    _static: () => {
+    toStatic: () => {
       //  Will process the two arrays, taking the first title in the array and returning <title>{string}</title>
       //  Then do a similar for the meta's. (will also need to add links, and add a linkQueue). Note that both queues
       //  will need a reset to prevent memory leaks.

--- a/src/dispatcher/index.ts
+++ b/src/dispatcher/index.ts
@@ -1,3 +1,4 @@
+import { createContext } from 'react';
 import { Name, CharSet, HttpEquiv, Property } from '../types';
 import { isServerSide } from '../utils';
 
@@ -20,7 +21,7 @@ export interface MetaPayload {
 }
 
 const applyTitleTemplate = (title: string, template?: string) =>
-  template ? template.replace(/%s/g, title  || '') : title;
+  template ? template.replace(/%s/g, title || '') : title;
 
 const changeOrCreateMetaTag = (meta: MetaPayload) => {
   const result = document.head.querySelectorAll(
@@ -65,7 +66,7 @@ const changeOrCreateMetaTag = (meta: MetaPayload) => {
  * would get switched out for Child2, this is a new batch and will be put in front of the
  * queue.
  */
-const createDispatcher = () => {
+export const createDispatcher = () => {
   let lang: string;
   let amp: 'module' | 'nomodule' | undefined;
   let linkQueue: any[] = [];
@@ -251,4 +252,7 @@ const createDispatcher = () => {
   };
 };
 
-export default createDispatcher();
+const defaultDispatcher = createDispatcher();
+
+export default defaultDispatcher;
+export const DispatcherContext = createContext(defaultDispatcher);

--- a/src/hooks/useAmp.ts
+++ b/src/hooks/useAmp.ts
@@ -1,8 +1,10 @@
-import dispatcher, { ampScriptSrc } from '../dispatcher';
+import { ampScriptSrc, DispatcherContext } from '../dispatcher';
 import { isServerSide } from '../utils';
-import { useEffect } from 'react';
+import { useContext, useEffect } from 'react';
 
 export const useAmp = (isModule: boolean, disabled?: boolean) => {
+  const dispatcher = useContext(DispatcherContext);
+
   if (isServerSide && !disabled) {
     dispatcher._setAmp(isModule);
   }

--- a/src/hooks/useHead.ts
+++ b/src/hooks/useHead.ts
@@ -1,5 +1,5 @@
-import { useEffect, useMemo, useRef } from 'react';
-import dispatcher, { META, MetaPayload, TITLE } from '../dispatcher';
+import { useContext, useEffect, useMemo, useRef } from 'react';
+import { DispatcherContext, META, MetaPayload, TITLE } from '../dispatcher';
 import { isServerSide } from '../utils';
 import { MetaOptions } from './useMeta';
 import { useAmp } from './useAmp';
@@ -22,6 +22,7 @@ export function extractKeyword(meta: MetaOptions) {
 }
 
 export const useHead = ({ title, metas, language, amp }: HeadObject) => {
+  const dispatcher = useContext(DispatcherContext);
   const hasMounted = useRef(false);
   const prevTitle = useRef<string | undefined>();
   const prevMetas = useRef<MetaPayload[]>();

--- a/src/hooks/useLang.ts
+++ b/src/hooks/useLang.ts
@@ -1,8 +1,10 @@
-import { useEffect } from 'react';
-import dispatcher from '../dispatcher';
+import { useContext, useEffect } from 'react';
+import { DispatcherContext } from '../dispatcher';
 import { isServerSide } from '../utils';
 
 export const useLang = (language: string) => {
+  const dispatcher = useContext(DispatcherContext);
+
   if (isServerSide) {
     dispatcher._setLang(language);
   }

--- a/src/hooks/useLink.ts
+++ b/src/hooks/useLink.ts
@@ -1,7 +1,7 @@
 import { Rel, As } from '../types';
-import { useEffect, useRef } from 'react';
+import { useContext, useEffect, useRef } from 'react';
 import { isServerSide } from '../utils';
-import dispatcher, { LINK } from '../dispatcher';
+import { DispatcherContext, LINK } from '../dispatcher';
 
 export interface LinkOptions {
   rel: Rel;
@@ -14,6 +14,7 @@ export interface LinkOptions {
 }
 
 export const useLink = (options: LinkOptions) => {
+  const dispatcher = useContext(DispatcherContext);
   const hasMounted = useRef(false);
   const node = useRef<Element | undefined>();
   const originalOptions = useRef<LinkOptions | undefined>();

--- a/src/hooks/useMeta.ts
+++ b/src/hooks/useMeta.ts
@@ -1,6 +1,6 @@
-import { useRef, useEffect } from 'react';
+import { useRef, useEffect, useContext } from 'react';
 import { Name, HttpEquiv, CharSet, Property } from '../types';
-import dispatcher, { MetaPayload, META } from '../dispatcher';
+import { MetaPayload, META, DispatcherContext } from '../dispatcher';
 import { isServerSide } from '../utils';
 import { extractKeyword } from './useHead';
 
@@ -13,6 +13,7 @@ export interface MetaOptions {
 }
 
 export const useMeta = (options: MetaOptions) => {
+  const dispatcher = useContext(DispatcherContext);
   const hasMounted = useRef(false);
   const keyword = useRef<string | undefined>();
   const metaObject = useRef<MetaPayload>({

--- a/src/hooks/useTitle.ts
+++ b/src/hooks/useTitle.ts
@@ -1,8 +1,9 @@
-import { useEffect, useRef } from 'react';
-import dispatcher, { TEMPLATE, TITLE } from '../dispatcher';
+import { useContext, useEffect, useRef } from 'react';
+import { DispatcherContext, TEMPLATE, TITLE } from '../dispatcher';
 import { isServerSide } from '../utils';
 
 export const useTitle = (title: string, template?: boolean) => {
+  const dispatcher = useContext(DispatcherContext);
   const hasMounted = useRef(false);
   const prevTitle = useRef<string | undefined>();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import dispatcher from './dispatcher';
 
+export { DispatcherContext, createDispatcher } from './dispatcher';
 export * from './hooks/useLang';
 export * from './hooks/useLink';
 export * from './hooks/useMeta';

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,4 +9,5 @@ export * from './hooks/useTitle';
 export * from './hooks/useTitleTemplate';
 export { useHead } from './hooks/useHead';
 export * from './types';
+export const toStatic = dispatcher.toStatic;
 export const HoofdProvider = DispatcherContext.Provider;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
-import dispatcher from './dispatcher';
+import dispatcher, { DispatcherContext } from './dispatcher';
 
-export { DispatcherContext, createDispatcher } from './dispatcher';
+export { createDispatcher } from './dispatcher';
 export * from './hooks/useLang';
 export * from './hooks/useLink';
 export * from './hooks/useMeta';
@@ -9,4 +9,4 @@ export * from './hooks/useTitle';
 export * from './hooks/useTitleTemplate';
 export { useHead } from './hooks/useHead';
 export * from './types';
-export const toStatic = dispatcher._static;
+export const HoofdProvider = DispatcherContext.Provider;


### PR DESCRIPTION
In case this is a feature that you're willing to entertain, I've put together what I think would address #34.

This PR:

- Introduces and exports a new `DispatcherContext` that is seeded with default export of `./dispatcher`.
- Exports the `createDispatcher` function, which is useful for setting up an isolated context provider with a distinct Dispatcher.
- Adjusts individual hooks to obtain a reference to the relevant Dispatcher using hooks instead of the module-level singleton.

Closes #34.