### PR TITLE
 Support for embedded data with useScript

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,13 @@ base `<html>` tag. Every time this string gets updated this will be reflected in
 This hook accepts a few arguments and will lead to an injection of a script tag into the dispatcher (during ssr)
 or the DOM (during csr).
 
-- src: this can be a location where the script lives, for example `public/x.js` or an inline script for example `data:application/javascript,alert("yolo")`.
+- src?: this can be a location where the script lives, for example `public/x.js` or an inline script for example `data:application/javascript,alert("yolo")`.
+- id?: a unique identifier used for querying the script tag. Atleast one among `src` and `id` prop is mandatory.
+- text?: this sets the inner `text` on the script tag. Can be used for adding [embedded data](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script#embedding_data_in_html), [rich text data](https://developers.google.com/search/docs/guides/intro-structured-data).
 - type?: this sets the `type` attribute on the script tag.
 - async?: this sets the `async` attribute on the script tag.
 - defer?: this sets the `defer` attribute on the script tag.
-- module?: this property will override the `type` atrribute on the script tag with a value of `module`. 
+- module?: this property will override the `type` atrribute on the script tag with a value of `module`.
 - crossorigin?: 'anonymous' | 'use-credentials';
 - integrity?: string;
 

--- a/__tests__/ssr.test.tsx
+++ b/__tests__/ssr.test.tsx
@@ -4,7 +4,15 @@ jest.mock('../src/utils', () => {
   };
 });
 import * as React from 'react';
-import { useTitle, toStatic, useMeta, useLink, useLang, useHead } from '../src';
+import {
+  useTitle,
+  toStatic,
+  useMeta,
+  useLink,
+  useLang,
+  useHead,
+  useScript,
+} from '../src';
 import { render } from '@testing-library/react';
 
 describe('ssr', () => {
@@ -26,16 +34,41 @@ describe('ssr', () => {
       useLang('nl');
       useMeta({ property: 'fb:admins', content: 'hi' });
       useLink({ rel: 'stylesheet', href: 'x' });
+      useScript({
+        crossorigin: 'anonymous',
+        type: 'application/javascript',
+        src: 'test.js',
+        async: true,
+      });
+      useScript({
+        text: '{"key":"value"}',
+        type: 'application/ld+json',
+        id: 'rich-text',
+      });
       return <p>hi</p>;
     };
 
     render(<MyComponent />);
     jest.runAllTimers();
-    const { lang, title, metas, links } = toStatic();
+    const { lang, title, metas, links, scripts } = toStatic();
+
     expect(lang).toEqual('nl');
     expect(title).toEqual('hi');
     expect(metas).toEqual([{ content: 'hi', property: 'fb:admins' }]);
     expect(links).toEqual([{ rel: 'stylesheet', href: 'x' }]);
+    expect(scripts).toEqual([
+      {
+        crossorigin: 'anonymous',
+        type: 'application/javascript',
+        src: 'test.js',
+        async: true,
+      },
+      {
+        text: '{"key":"value"}',
+        type: 'application/ld+json',
+        id: 'rich-text',
+      },
+    ]);
   });
 
   it('should render to string (basic-useHead)', () => {
@@ -61,6 +94,13 @@ describe('ssr', () => {
       useTitle('hi');
       useMeta({ property: 'fb:admins', content: 'hi' });
       useLink({ rel: 'stylesheet', href: 'x' });
+      useScript({
+        crossorigin: 'anonymous',
+        type: 'application/javascript',
+        src: 'test.js',
+        async: true,
+      });
+
       return props.children;
     };
 
@@ -68,6 +108,12 @@ describe('ssr', () => {
       useTitle('bye');
       useMeta({ property: 'fb:admins', content: 'bye' });
       useLink({ rel: 'stylesheet', href: 'y' });
+      useScript({
+        text: '{"key":"value"}',
+        type: 'application/ld+json',
+        id: 'rich-text',
+      });
+
       return <p>hi</p>;
     };
 
@@ -77,12 +123,25 @@ describe('ssr', () => {
       </MyComponent>
     );
     jest.runAllTimers();
-    const { title, metas, links } = toStatic();
+    const { title, metas, links, scripts } = toStatic();
     expect(title).toEqual('bye');
     expect(metas).toEqual([{ content: 'bye', property: 'fb:admins' }]);
     expect(links).toEqual([
       { rel: 'stylesheet', href: 'x' },
       { rel: 'stylesheet', href: 'y' },
+    ]);
+    expect(scripts).toEqual([
+      {
+        crossorigin: 'anonymous',
+        type: 'application/javascript',
+        src: 'test.js',
+        async: true,
+      },
+      {
+        text: '{"key":"value"}',
+        type: 'application/ld+json',
+        id: 'rich-text',
+      },
     ]);
   });
 

--- a/__tests__/useScript.test.tsx
+++ b/__tests__/useScript.test.tsx
@@ -57,4 +57,23 @@ describe('useScript', () => {
       '<script type="application/javascript" crossorigin="anonymous" async="true" src="test.js"></script>'
     );
   });
+
+  it('should fill in the script with text', () => {
+    const MyComponent = () => {
+      useScript({
+        text: '{"key":"value"}',
+        type: 'application/ld+json',
+        id: 'rich-text',
+      });
+      return <p>hi</p>;
+    };
+
+    act(() => {
+      render(<MyComponent />);
+    });
+
+    expect(document.head.innerHTML).toContain(
+      '<script type="application/ld+json" id="rich-text">{"key":"value"}</script>'
+    );
+  });
 });

--- a/__tests__/useScript.test.tsx
+++ b/__tests__/useScript.test.tsx
@@ -76,4 +76,34 @@ describe('useScript', () => {
       '<script type="application/ld+json" id="rich-text">{"key":"value"}</script>'
     );
   });
+
+  it('should reuse an existing tag to fill text', () => {
+    const MyComponent = () => {
+      useScript({
+        text: '{"key":"value"}',
+        type: 'application/ld+json',
+        id: 'rich-text',
+      });
+      return <p>hi</p>;
+    };
+
+    const node = document.createElement('script');
+    const options = {
+      type: 'application/ld+json',
+      id: 'rich-text',
+    };
+    Object.keys(options).forEach((key) => {
+      // @ts-ignore
+      (node as Element).setAttribute(key, options[key]);
+    });
+    document.head.appendChild(node);
+
+    act(() => {
+      render(<MyComponent />);
+    });
+
+    expect(document.head.innerHTML).toContain(
+      '<script type="application/ld+json" id="rich-text">{"key":"value"}</script>'
+    );
+  });
 });

--- a/packages/gatsby-plugin-hoofd/gatsby-ssr.js
+++ b/packages/gatsby-plugin-hoofd/gatsby-ssr.js
@@ -1,11 +1,11 @@
-import { createElement } from 'react';
+import React, { createElement } from 'react';
 import { toStatic } from 'hoofd';
 
 export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
   const { title, metas, lang, links, scripts } = toStatic();
 
-  if (lang || amp) {
-    setHtmlAttributes({ lang, amp });
+  if (lang) {
+    setHtmlAttributes({ lang });
   }
 
   setHeadComponents(
@@ -13,7 +13,14 @@ export const onRenderBody = ({ setHeadComponents, setHtmlAttributes }) => {
       title && createElement('title', null, title),
       ...metas.map((meta) => createElement('meta', meta, null)),
       ...links.map((link) => createElement('link', link, null)),
-      ...scripts.map(({ module, ...script }) => createElement('script', { ...script, type: module ? 'module' : undefined }, null)),
+      ...scripts.map(({ module, text, type, ...script }) => (
+        <script
+          type={module ? 'module' : type}
+          key={script.id || script.src}
+          {...script}
+          dangerouslySetInnerHTML={{ __html: text }}
+        />
+      )),
     ].filter(Boolean)
   );
 };

--- a/src/hooks/useScript.ts
+++ b/src/hooks/useScript.ts
@@ -3,7 +3,9 @@ import { isServerSide } from '../utils';
 import { DispatcherContext, SCRIPT } from '../dispatcher';
 
 export interface ScriptOptions {
-  src: string;
+  src?: string;
+  id?: string;
+  text?: string;
   type?: string;
   async?: boolean;
   defer?: boolean;
@@ -20,13 +22,13 @@ export const useScript = (options: ScriptOptions) => {
   }
 
   useEffect(() => {
-    const preExistingElements = document.querySelectorAll(
-      `script[src="${options.src}"]`
-    );
+    const preExistingElements = options.id
+      ? document.querySelectorAll(`script[id="${options.id}"]`)
+      : document.querySelectorAll(`script[src="${options.src}"]`);
 
     let script: HTMLScriptElement;
 
-    if (!preExistingElements[0] && options.src) {
+    if (!preExistingElements[0] && (options.src || options.id)) {
       const script = document.createElement('script');
 
       if (options.type) script.type = options.type;
@@ -39,7 +41,12 @@ export const useScript = (options: ScriptOptions) => {
       if (options.defer) script.setAttribute('defer', 'true');
       else if (options.async) script.setAttribute('async', 'true');
 
-      script.src = options.src;
+      if (options.id) script.id = options.id;
+
+      if (options.src) script.src = options.src;
+
+      if (options.text) script.text = options.text;
+
       document.head.appendChild(script);
     } else if (preExistingElements[0]) {
       script = preExistingElements[0] as HTMLScriptElement;


### PR DESCRIPTION
This PR includes the following changes

- Includes ability to add embedded data to the `useScript` hook. Solves #43. 
- Changes for `gatsby-plugin-hoofd` to support this ability.
- Updated SSR test cases to include `useScript` hook.
- Removed unused `amp` variable