### PR TITLE
feat: support Gatsby v3

### DIFF
--- a/packages/gatsby-plugin-hoofd/package.json
+++ b/packages/gatsby-plugin-hoofd/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {},
   "peerDependencies": {
     "hoofd": "^1.0.0",
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I use the plugin with Gatsby v3 for a while. It works great. This small change should remove this warning from the build process:

`Plugin gatsby-plugin-hoofd is not compatible with your gatsby version 3.10.0 - It requires gatsby@^2.0.0`