### PR TITLE
build: support Gatsby v4

### DIFF
--- a/packages/gatsby-plugin-hoofd/package.json
+++ b/packages/gatsby-plugin-hoofd/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {},
   "peerDependencies": {
     "hoofd": "^1.0.0",
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0""
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "repository": {
     "type": "git",

--- a/packages/gatsby-plugin-hoofd/package.json
+++ b/packages/gatsby-plugin-hoofd/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {},
   "peerDependencies": {
     "hoofd": "^1.0.0",
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hey,

Gatsby v4 is out. The APIs your plugin is using didn't have any changes. This small change will remove a warning when installing the plugin.

Thanks a bunch,
Benedikt