### PR TITLE
add: add dns-prefetch to rel type

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,7 @@ export type Rel =
   | 'canonical'
   | 'preload'
   | 'prefetch'
+  | 'dns-prefetch'
   | 'preconnect'
   | 'modulepreload';
 


### PR DESCRIPTION
This allows users to set the (experimental, but very awesome) https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/dns-prefetch rel tag